### PR TITLE
Create dynamic form field script

### DIFF
--- a/README-Field-Copy-Script.md
+++ b/README-Field-Copy-Script.md
@@ -1,0 +1,81 @@
+# Formstack Field Copy Script
+
+This script uses the Formstack fsApi (Embed field API) to copy values from one field to another with console logging.
+
+## Features
+
+- Monitors a source field for changes
+- Console.logs all values for debugging
+- Automatically copies values to a target field
+- Handles initial values when the form loads
+- Soft-coded field IDs for reuse across multiple forms
+
+## How to Use
+
+### Step 1: Get Your Field IDs
+
+1. Open your Formstack form in the form builder
+2. Click on the source field you want to monitor
+3. Look at the URL or inspect the field to get its ID
+4. Repeat for the target field
+
+### Step 2: Configure the Script
+
+Replace these placeholder values in the script:
+
+```javascript
+const FORM_ID = "YOUR_FORM_ID";           // Replace with your form ID
+const SOURCE_FIELD_ID = "SOURCE_FIELD";   // Replace with source field ID  
+const TARGET_FIELD_ID = "TARGET_FIELD";   // Replace with target field ID
+```
+
+### Step 3: Add to Your Form
+
+1. In the Formstack form builder, add an "Embed" field
+2. Copy the content inside the `<script>` tags from `embed-field-copy-script.html`
+3. Paste it into the embed field content area
+4. Save your form
+
+### Example Configuration
+
+```javascript
+const FORM_ID = "6113001";
+const SOURCE_FIELD_ID = "180770306";
+const TARGET_FIELD_ID = "180770343";
+```
+
+## Console Output
+
+The script will log the following information to the browser console:
+
+- Script initialization confirmation
+- Field change detection
+- Source field values
+- Actual values being copied
+- Copy completion confirmation
+- Initial value handling
+
+## Compatible Field Types
+
+This script works with most Formstack field types including:
+- Short Answer (Text)
+- Long Answer (Textarea)  
+- Email
+- Phone
+- Number
+- Select/Dropdown
+- And more
+
+## Troubleshooting
+
+1. **Check the browser console** for error messages and debug output
+2. **Verify field IDs** are correct by inspecting the form fields
+3. **Ensure the form ID** matches your actual form
+4. **Test with simple text fields** first before using with complex field types
+
+## Important Notes
+
+- Formstack cannot provide support for custom JavaScript
+- Test thoroughly before deploying to production forms
+- The script handles both change events and initial form load
+- Console logging helps with debugging field value issues

--- a/embed-field-copy-script.html
+++ b/embed-field-copy-script.html
@@ -1,0 +1,77 @@
+<html>
+  <body>
+    <script>
+      // Formstack can not provide support for custom javascript.
+      // Replace with appropriate values for your specific form
+      "use strict";
+
+      // CONFIGURATION: Update these values for each form
+      const FORM_ID = "YOUR_FORM_ID";           // Replace with your form ID
+      const SOURCE_FIELD_ID = "SOURCE_FIELD";   // Replace with source field ID
+      const TARGET_FIELD_ID = "TARGET_FIELD";   // Replace with target field ID
+
+      const form = window.fsApi().getForm(FORM_ID);
+
+      // Function to handle copying values from source to target field
+      function handleValueCopy(event) {
+        // Only process changes to our source field
+        if (event.data.fieldId !== SOURCE_FIELD_ID) {
+          return Promise.resolve(event);
+        }
+
+        console.log("Field change detected on source field:", SOURCE_FIELD_ID);
+
+        const sourceField = form.getField(SOURCE_FIELD_ID);
+        const targetField = form.getField(TARGET_FIELD_ID);
+
+        // Get the current value from source field
+        const sourceValue = sourceField.getValue();
+        console.log("Source field value:", sourceValue);
+
+        // Extract the actual value (handling different field types)
+        const actualValue = sourceValue.value || sourceValue;
+        console.log("Actual value to copy:", actualValue);
+
+        // Set the target field to the source value
+        targetField.setValue({ value: actualValue });
+        console.log("Value copied to target field:", TARGET_FIELD_ID);
+
+        return Promise.resolve(event);
+      }
+
+      // Register the change event listener
+      form.registerFormEventListener({
+        type: "change",
+        onFormEvent: handleValueCopy,
+      });
+
+      // Handle initial value when form loads
+      form.registerFormEventListener({
+        type: "ready",
+        onFormEvent: function (event) {
+          console.log("Form ready, checking for initial values...");
+          
+          const sourceField = form.getField(SOURCE_FIELD_ID);
+          const initialValue = sourceField.getValue();
+
+          if (initialValue && (initialValue.value || initialValue)) {
+            console.log("Initial value found in source field:", initialValue);
+            handleValueCopy({
+              data: {
+                fieldId: SOURCE_FIELD_ID,
+              },
+            });
+          } else {
+            console.log("No initial value found in source field");
+          }
+          
+          return Promise.resolve(event);
+        },
+      });
+
+      console.log("Field copy script initialized for form:", FORM_ID);
+      console.log("Monitoring source field:", SOURCE_FIELD_ID);
+      console.log("Target field:", TARGET_FIELD_ID);
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
A new script, `embed-field-copy-script.html`, was created to copy values between Formstack fields.

*   The script utilizes the Formstack Embed field API (`fsApi`) to read a source field's value, log it to the console, and then set a target field's value.
*   It features soft-coded constants (`FORM_ID`, `SOURCE_FIELD_ID`, `TARGET_FIELD_ID`) for easy reuse across different forms.
*   Event listeners were implemented for both `change` events (for real-time updates) and `ready` events (to handle initial form load values), ensuring comprehensive value synchronization.
*   The script's design was informed by a review of the `organization-wide-resources/context-documents/formstack-forms-form-render-01-fsApi.md` documentation.
*   Additionally, a `README-Field-Copy-Script.md` was generated, providing a usage guide, configuration instructions, and troubleshooting tips for the script.